### PR TITLE
multi api keys support

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -274,9 +274,14 @@ def create_key_bindings(settings: ChatSettings):
 def main(args):
     # 从 .env 文件中读取 OPENAI_API_KEY
     load_dotenv()
-    api_key = os.environ.get("OPENAI_API_KEY")
+    if args.key:
+        api_key = os.environ.get(args.key)
+    else:
+        api_key = os.environ.get("OPENAI_API_KEY")
+    # if 'key' arg triggered, load the api key from .env with the given key-name;
+    # otherwise load the api key with the key-name "OPENAI_API_KEY"
     if not api_key:
-        api_key = prompt("OpenAI API Key: ")
+        api_key = prompt("OpenAI API Key not found, please input: ")
     api_timeout = int(os.environ.get("OPENAI_API_TIMEOUT", "20"))
 
     chatGPT = CHATGPT(api_key)
@@ -347,6 +352,7 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Chat with GPT-3.5')
     parser.add_argument('--load', metavar='FILE', type=str, help='Load chat history from file')
+    parser.add_argument('--key', type=str, help='choose the API key to load')
     parser.add_argument('-m', '--multi', action='store_true',
                         help='Enable multi-line mode')
     parser.add_argument('-r', '--raw', action='store_true',


### PR DESCRIPTION
增加在.env文件中添加多个API密钥的支持

比如 我在.env里加上我的第二个key：
`OPENAI_API_KEY_2=sk-2xxxx`

那么在启动时 可以通过`python chat.py --key OPENAI_API_KEY_2`来调用新添加的key
若没有指定`--key`则自动调用`OPENAI_API_KEY`

主要是为了方便那些可能会有多key切换需求的人