### PR TITLE
Model-change support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 chat.log
 .env
 chat*.json
+
+*.code-workspace
+# ignore vscode workspace file

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Supports saving chat messages to a JSON file and loading them from the file.
 
 ![example](README.assets/small.gif)
 
-Uses the [gpt-3.5-turbo](https://platform.openai.com/docs/guides/chat/chat-completions-beta) model, which is the same model used by ChatGPT (Free Edition).
+Uses the [gpt-3.5-turbo](https://platform.openai.com/docs/guides/chat/chat-completions-beta) model, which is the same model used by ChatGPT (Free Edition), as default.
 
 ## Installation
 
@@ -70,7 +70,11 @@ Original chat logs will be saved to `chat.log`
 
 - `/tokens`: Display the API token count and token length for the current conversation
 
-  > GPT-3.5 has a token limit of 4097; use this command to check if you're approaching the limit
+  > GPT-3.5 has a token limit of 4096; use this command to check if you're approaching the limit
+
+- `/model`: Show or change the Model in use
+
+  > `gpt-4` , `gpt-4-32k` , `gpt-3.5-turbo` are supported by default. when using other models you need to change the API endpoint in code.
 
 - `/last`: Show the last reply
 
@@ -97,6 +101,7 @@ options:
   -h, --help     Show this help message and exit
   --load FILE    Load chat history from file
   --key API_KEY  Select which API key in .env file to use
+  --model MODEL  Choose which AI model to use
   -m, --multi    Enable multi-line mode
   -r, --raw      Enable raw mode
 ```
@@ -117,9 +122,13 @@ You can also use `Ctrl-D` or `/exit` to exit immediately.
 
 Upon exit, the token count for the chat session will be displayed.
 
-> Current price: $0.002 / 1K tokens, Free Edition rate limit: 20 requests / min
+> Current price: $0.002 / 1K tokens, Free Edition rate limit: 20 requests / min (`gpt-3.5-turbo`)
 
 ## Changelog
+
+### 2023-03-28
+
+- Add `--model` runtime argument and `/model` command to choose / change AI models.
 
 ### 2023-03-27
 

--- a/README.md
+++ b/README.md
@@ -94,10 +94,11 @@ Original chat logs will be saved to `chat.log`
 
 ```shell
 options:
-  -h, --help   show this help message and exit
-  --load FILE  Load chat history from file
-  -m, --multi  Enable multi-line mode
-  -r, --raw    Enable raw mode
+  -h, --help     Show this help message and exit
+  --load FILE    Load chat history from file
+  --key API_KEY  Select which API key in .env file to use
+  -m, --multi    Enable multi-line mode
+  -r, --raw      Enable raw mode
 ```
 
 > Multi-line mode and raw mode can be used simultaneously
@@ -119,6 +120,10 @@ Upon exit, the token count for the chat session will be displayed.
 > Current price: $0.002 / 1K tokens, Free Edition rate limit: 20 requests / min
 
 ## Changelog
+
+### 2023-03-27
+
+- Added `--key` runtime argument to select which API key in the `.env` file to use.
 
 ### 2023-03-23
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -96,10 +96,11 @@ python3 chat.py
 
 ```shell
 options:
-  -h, --help   show this help message and exit
-  --load FILE  Load chat history from file
-  -m, --multi  Enable multi-line mode
-  -r, --raw    Enable raw mode
+  -h, --help     Show this help message and exit
+  --load FILE    Load chat history from file
+  --key API_KEY  Select which API key in .env file to use
+  -m, --multi    Enable multi-line mode
+  -r, --raw      Enable raw mode
 ```
 
 > 多行模式与 raw 模式可以同时使用
@@ -121,6 +122,10 @@ options:
 > 目前价格为: $0.002 / 1K tokens，免费版速率限制为: 20次 / min
 
 ## Changelog
+
+### 2023-03-27
+
+- 增加 `--key` 运行参数，用于选择使用哪一个储存在 `.env` 文件中的API key
 
 ### 2023-03-23
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,7 +19,7 @@
 
 ![example](README.assets/small.gif)
 
-使用 [gpt-3.5-turbo](https://platform.openai.com/docs/guides/chat/chat-completions-beta) 模型，也就是 ChatGPT(免费版) 所使用的模型。
+默认使用 [gpt-3.5-turbo](https://platform.openai.com/docs/guides/chat/chat-completions-beta) 模型，也就是 ChatGPT(免费版) 所使用的模型。
 
 ## 安装
 
@@ -72,7 +72,11 @@ python3 chat.py
 
 - `/tokens`：显示已用的 API token 数统计和本次对话的 token 长度
 
-  > GPT-3.5的对话token限制为4097，可通过此命令实时查看是否接近限制
+  > GPT-3.5的对话token限制为4096，可通过此命令实时查看是否接近限制
+
+- `/model`：显示或选择使用的模型
+
+  > 默认支持 `gpt-4`，`gpt-4-32k`，`gpt-3.5-turbo`，其余的模型需要在代码内更改 API endpoint
 
 - `/last`：显示最后一条回复
 
@@ -99,6 +103,7 @@ options:
   -h, --help     Show this help message and exit
   --load FILE    Load chat history from file
   --key API_KEY  Select which API key in .env file to use
+  --model MODEL  Choose which AI model to use
   -m, --multi    Enable multi-line mode
   -r, --raw      Enable raw mode
 ```
@@ -119,9 +124,13 @@ options:
 
 退出后将显示本次聊天所使用的 tokens 统计
 
-> 目前价格为: $0.002 / 1K tokens，免费版速率限制为: 20次 / min
+> 目前价格为: $0.002 / 1K tokens，免费版速率限制为: 20次 / min (`gpt-3.5-turbo`)
 
 ## Changelog
+
+### 2023-03-28
+
+- 增加 `--model` 运行参数和 `/model` 命令，用于选择 / 更改使用的模型
 
 ### 2023-03-27
 

--- a/chat.py
+++ b/chat.py
@@ -292,7 +292,7 @@ def main(args):
 
     try:
         console.print(
-            "[dim]Hi, welcome to chat with GPT. Type `[bright_magenta]\help[/]` to display available commands.")
+            "[dim]Hi, welcome to chat with GPT. Type `[bright_magenta]/help[/]` to display available commands.")
 
         if args.multi:
             chat_settings.toggle_multi_line_mode()


### PR DESCRIPTION
增加了以下支持：
- `--model`运行参数 运行在启动时指定调用的模型
- `/model`命令 允许在运行过程中查看正在使用的模型或更改使用的模型

修改：
- 启动title中的`\help`修改为`/help`
- 增加了在更改模型时 调用`/tokens`命令时对tokens限制的判断【仅判断gpt4, gpt4-32k, gpt3.5-turbo】
- 更新双语README 加上了对#7和#8增加内容的描述