### PR TITLE
Message delete (when approaching tokens limit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Original chat logs will be saved to `chat.log`
 
   > GPT-3.5 has a token limit of 4096; use this command to check if you're approaching the limit
 
-- `/usage`: Display the API credits summary
+- `/usage`: ~~Display the API credits summary~~ Currently unavailable
 
 - `/model`: Show or change the Model in use
 
@@ -89,6 +89,12 @@ Original chat logs will be saved to `chat.log`
   - `/copy code [index]`: Copy the `index`-th code block from the last reply's content to the clipboard
 
     > If `index` is not specified, the terminal will print all code blocks and ask for the number of the one to be copied
+
+- `/delete` or `/delete first`: delete the first question and answer in the current chat
+
+     > When the token is about to reach the upper limit, the user will be warned, and when the upper limit has been exceeded, it will be asked whether to delete the first message
+
+   - `/delete all`: delete all messages
 
 - `/save [filename_or_path]`: Save the chat history to the specified JSON file
 
@@ -137,6 +143,10 @@ Upon exit, the token count for the chat session will be displayed.
 > Current price: $0.002 / 1K tokens, Free Edition rate limit: 20 requests / min (`gpt-3.5-turbo`)
 
 ## Changelog
+
+### 2023-04-05
+
+- Add `/delete` command to delete the first question and answer in this chat to reduce token.
 
 ### 2023-04-01
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -78,7 +78,7 @@ python3 chat.py
 
   > GPT-3.5的对话token限制为4096，可通过此命令实时查看是否接近限制
 
-- `/usage`：显示已用的 API 的账号余额
+- `/usage`：~~显示已用的 API 的账号余额~~ 暂时不可用
 
 - `/model`：显示或选择使用的模型
 
@@ -91,6 +91,12 @@ python3 chat.py
   - `/copy code [index]`：将最后一条回复内容中的第 `index` 块代码复制至剪切板
 
     > 如果不指定 `index`，则终端会打印所有代码块并询问要复制的序号
+
+- `/delete` 或 `/delete first`：将当前会话第一条提问和回答内容删除
+
+    > 在会话 token 将要达到上限时会提示用户，已经超出上限时会询问是否删除第一条信息
+
+  - `/delete all`：将所有会话删除
 
 - `/save [filename_or_path]`：将聊天记录保存到指定的 JSON 文件中
 
@@ -139,6 +145,10 @@ options:
 > 目前价格为: $0.002 / 1K tokens，免费版速率限制为: 20次 / min (`gpt-3.5-turbo`)
 
 ## Changelog
+
+### 2023-04-05
+
+- 添加`/delete`命令删除本次对话中的第一个问题和答案以减少 token
 
 ### 2023-04-01
 

--- a/TODO.md
+++ b/TODO.md
@@ -24,7 +24,7 @@
 
 - [x] Ctrl-C中断等待，Ctrl-D退出程序
 
-- [ ] tokens上限达到后询问是否删除第一条message
+- [x] tokens上限达到后询问是否删除第一条message
 
   
 

--- a/chat.py
+++ b/chat.py
@@ -262,7 +262,7 @@ class ChatGPT:
 
 class CustomCompleter(Completer):
     commands = [
-        '/raw', '/multi', '/stream', '/tokens', '/usage', '/last', '/copy', '/model', '/save', '/system', '/timeout', '/undo', '/delete', '/help', '/exit'
+        '/raw', '/multi', '/stream', '/tokens', '/last', '/copy', '/model', '/save', '/system', '/timeout', '/undo', '/delete', '/help', '/exit'
     ]
 
     copy_actions = [
@@ -422,6 +422,7 @@ def handle_command(command: str, chat_gpt: ChatGPT):
                             f"[bold bright_yellow]Used:[/]\t\t${credit_usage.get('total_used')}\n"
                             f"[bold green]Available:[/]\t${credit_usage.get('total_available')}",
                             title=credit_usage.get('object'), title_align='left', width=35, style='dim'))
+        console.print("[red]`[bright_magenta]/usage[/]` command is currently unavailable, it's not sure if this command will be available again or not.")
 
     elif command.startswith('/model'):
         args = command.split()
@@ -528,7 +529,6 @@ def handle_command(command: str, chat_gpt: ChatGPT):
     /multi                   - Toggle multi-line mode (allow multi-line input)
     /stream                  - Toggle stream output mode (flow print the answer)
     /tokens                  - Show the total tokens spent and the tokens for the current conversation
-    /usage                   - Show total credits and current credits used
     /last                    - Display last ChatGPT's reply
     /copy (all)              - Copy the full ChatGPT's last reply (raw) to Clipboard
     /copy code \[index]       - Copy the code in ChatGPT's last reply to Clipboard

--- a/chat.py
+++ b/chat.py
@@ -478,8 +478,8 @@ def handle_command(command: str, chatGPT: ChatGPT):
             new_timeout = args[1]
         else:
             new_timeout = prompt(
-                "OpenAI API timeout: ", default=str(ChatMode.timeout), style=style)
-        if new_timeout != str(ChatMode.timeout):
+                "OpenAI API timeout: ", default=str(chatGPT.timeout), style=style)
+        if new_timeout != str(chatGPT.timeout):
             chatGPT.set_timeout(new_timeout)
         else:
             console.print("[dim]No change.")

--- a/chat.py
+++ b/chat.py
@@ -398,7 +398,7 @@ def copy_code(message, select_code_idx: int = None):
     console.print("[dim]Code copied to Clipboard")
 
 
-def handle_command(command: str, chatGPT: ChatGPT):
+def handle_command(command: str, chat_gpt: ChatGPT):
     '''处理斜杠(/)命令'''
     if command == '/raw':
         ChatMode.toggle_raw_mode()
@@ -414,13 +414,13 @@ def handle_command(command: str, chatGPT: ChatGPT):
         
         # tokens limit judge moved to ChatGPT.set_model function
 
-        console.print(Panel(f"[bold bright_magenta]Total Tokens Spent:[/]\t{chatGPT.total_tokens_spent}\n"
-                            f"[bold green]Current Tokens:[/]\t\t{chatGPT.current_tokens}/[bold]{chatGPT.tokens_limit}",
+        console.print(Panel(f"[bold bright_magenta]Total Tokens Spent:[/]\t{chat_gpt.total_tokens_spent}\n"
+                            f"[bold green]Current Tokens:[/]\t\t{chat_gpt.current_tokens}/[bold]{chat_gpt.tokens_limit}",
                             title='token_summary', title_align='left', width=40, style='dim'))
 
     elif command == '/usage':
         with console.status("Getting credit usage...") as status:
-            credit_usage = chatGPT.get_credit_usage()
+            credit_usage = chat_gpt.get_credit_usage()
         if not credit_usage:
             return
         console.print(Panel(f"[bold blue]Total Granted:[/]\t${credit_usage.get('total_granted')}\n"
@@ -434,19 +434,19 @@ def handle_command(command: str, chatGPT: ChatGPT):
             new_model = args[1]
         else:
             new_model = prompt(
-                "OpenAI API model: ", default=chatGPT.model, style=style)
-        if new_model != chatGPT.model:
-            chatGPT.set_model(new_model)
+                "OpenAI API model: ", default=chat_gpt.model, style=style)
+        if new_model != chat_gpt.model:
+            chat_gpt.set_model(new_model)
         else:
             console.print("[dim]No change.")
 
     elif command == '/last':
-        reply = chatGPT.messages[-1]
+        reply = chat_gpt.messages[-1]
         print_message(reply)
 
     elif command.startswith('/copy'):
         args = command.split()
-        reply = chatGPT.messages[-1]
+        reply = chat_gpt.messages[-1]
         if len(args) > 1:
             if args[1] == 'all':
                 pyperclip.copy(reply["content"])
@@ -470,7 +470,7 @@ def handle_command(command: str, chatGPT: ChatGPT):
         else:
             date_filename = f'./chat_history_{datetime.now().strftime("%Y-%m-%d_%H,%M,%S")}.json'
             filename = prompt("Save to: ", default=date_filename, style=style)
-        chatGPT.save_chat_history(filename)
+        chat_gpt.save_chat_history(filename)
 
     elif command.startswith('/system'):
         args = command.split()
@@ -478,9 +478,9 @@ def handle_command(command: str, chatGPT: ChatGPT):
             new_content = ' '.join(args[1:])
         else:
             new_content = prompt(
-                "System prompt: ", default=chatGPT.messages[0]['content'], style=style)
-        if new_content != chatGPT.messages[0]['content']:
-            chatGPT.modify_system_prompt(new_content)
+                "System prompt: ", default=chat_gpt.messages[0]['content'], style=style)
+        if new_content != chat_gpt.messages[0]['content']:
+            chat_gpt.modify_system_prompt(new_content)
         else:
             console.print("[dim]No change.")
 
@@ -490,17 +490,17 @@ def handle_command(command: str, chatGPT: ChatGPT):
             new_timeout = args[1]
         else:
             new_timeout = prompt(
-                "OpenAI API timeout: ", default=str(chatGPT.timeout), style=style)
-        if new_timeout != str(chatGPT.timeout):
-            chatGPT.set_timeout(new_timeout)
+                "OpenAI API timeout: ", default=str(chat_gpt.timeout), style=style)
+        if new_timeout != str(chat_gpt.timeout):
+            chat_gpt.set_timeout(new_timeout)
         else:
             console.print("[dim]No change.")
 
     elif command == '/undo':
-        if len(chatGPT.messages) > 2:
-            question = chatGPT.messages.pop()
+        if len(chat_gpt.messages) > 2:
+            question = chat_gpt.messages.pop()
             if question['role'] == "assistant":
-                question = chatGPT.messages.pop()
+                question = chat_gpt.messages.pop()
             truncated_question = question['content'].split('\n')[0]
             if len(question['content']) > len(truncated_question):
                 truncated_question += "..."
@@ -513,16 +513,16 @@ def handle_command(command: str, chatGPT: ChatGPT):
         args = command.split()
         if len(args) > 1:
             if args[1] == 'first':
-                chatGPT.delete_first_conversation()
+                chat_gpt.delete_first_conversation()
             elif args[1] == 'all':
-                del chatGPT.messages[1:]
-                chatGPT.current_tokens = count_token(chatGPT.messages)
+                del chat_gpt.messages[1:]
+                chat_gpt.current_tokens = count_token(chat_gpt.messages)
                 # recount current tokens
                 console.print("[dim]Current chat deleted.")
             else:
                 console.print("[dim]Nothing to do. Avaliable delete command: `[bright_magenta]/delete first[/]` or `[bright_magenta]/delete all[/]`")
         else:
-            chatGPT.delete_first_conversation()
+            chat_gpt.delete_first_conversation()
 
     elif command == '/exit':
         raise EOFError

--- a/chat.py
+++ b/chat.py
@@ -184,7 +184,7 @@ class ChatGPT:
                 self.current_tokens = count_token(self.messages)
                 self.total_tokens_spent += self.current_tokens
 
-                if self.tokens_limit - self.current_tokens in range(0, 500):
+                if self.tokens_limit - self.current_tokens in range(1, 500):
                     console.print(f"[dim]Approaching the tokens limit: {self.tokens_limit - self.current_tokens} tokens left", new_line_start=True)
                 # approaching tokens limit (less than 500 left), show info
                 elif self.current_tokens >= self.tokens_limit:

--- a/chat.py
+++ b/chat.py
@@ -268,7 +268,7 @@ class ChatGPT:
 
 class CustomCompleter(Completer):
     commands = [
-        '/raw', '/multi', '/stream', '/tokens', '/usage', '/last', '/copy', '/model', '/save', '/system', '/timeout', '/undo', '/del', '/help', '/exit'
+        '/raw', '/multi', '/stream', '/tokens', '/usage', '/last', '/copy', '/model', '/save', '/system', '/timeout', '/undo', '/delfirst', '/help', '/exit'
     ]
 
     copy_actions = [
@@ -497,7 +497,7 @@ def handle_command(command: str, chatGPT: ChatGPT):
         else:
             console.print("[dim]Nothing to undo.")
 
-    elif command == '/del':
+    elif command == '/delfirst':
         chatGPT.delete_first_conversation()
 
     elif command == '/exit':
@@ -518,6 +518,7 @@ def handle_command(command: str, chatGPT: ChatGPT):
     /system \[new_prompt]     - Modify the system prompt
     /timeout \[new_timeout]   - Modify the api timeout
     /undo                    - Undo the last question and remove its answer
+    /delfirst                - Delete the first conversation in current chat
     /help                    - Show this help message
     /exit                    - Exit the application''')
 

--- a/chat.py
+++ b/chat.py
@@ -17,6 +17,7 @@ from prompt_toolkit import PromptSession, prompt
 from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.keys import Keys
+from prompt_toolkit.shortcuts import confirm
 from prompt_toolkit.styles import Style
 from prompt_toolkit.validation import ValidationError, Validator
 from rich import print as rprint
@@ -68,14 +69,6 @@ class ChatMode:
         else:
             console.print(f"[dim]Multi-line mode disabled.")
 
-class YesOrNoValidator(Validator):
-    def validate(self, document):
-        text = document.text
-        if text != "Y" and text != "n":
-            raise ValidationError(message="Please input 'Y' or 'n'!",
-                                  cursor_position=len(text))
-
-
 class ChatGPT:
     def __init__(self, api_key: str, timeout: int):
         self.api_key = api_key
@@ -87,7 +80,7 @@ class ChatGPT:
         self.messages = [
             {"role": "system", "content": "You are a helpful assistant."}]
         self.model = 'gpt-3.5-turbo'
-        self.tokens_limit = 4096
+        self.tokens_limit = 50
         # as default: gpt-3.5-turbo has a tokens limit as 4096
         # when model changes, tokens will also be changed
         self.total_tokens_spent = 0
@@ -187,9 +180,11 @@ class ChatGPT:
                     console.print(f"[dim]Approaching the tokens limit: {self.tokens_limit - self.current_tokens} tokens left", new_line_start=True)
                 # approaching tokens limit (less than 500 left), show info
                 elif self.current_tokens >= self.tokens_limit:
-                    delfirst_YN = prompt(
-                        "Reached tokens limit, do you want to delete the first conversation of current chat? (Y/n): ", style=style, validator=YesOrNoValidator())
-                    if delfirst_YN == 'Y':
+                    print()
+                    # writeline
+                    delfirst_YN = confirm(
+                        "Reached tokens limit, do you want to delete the first conversation of current chat?")
+                    if delfirst_YN:
                         self.delete_first_conversation()
 
         except Exception as e:

--- a/chat.py
+++ b/chat.py
@@ -80,7 +80,7 @@ class ChatGPT:
         self.messages = [
             {"role": "system", "content": "You are a helpful assistant."}]
         self.model = 'gpt-3.5-turbo'
-        self.tokens_limit = 50
+        self.tokens_limit = 4096
         # as default: gpt-3.5-turbo has a tokens limit as 4096
         # when model changes, tokens will also be changed
         self.total_tokens_spent = 0

--- a/chat.py
+++ b/chat.py
@@ -177,6 +177,13 @@ class ChatGPT:
             response = self.send_request(data)
             if response is None:
                 self.messages.pop()
+                if self.current_tokens >= self.tokens_limit:
+                    print()
+                    # writeline
+                    delfirst_YN = confirm(
+                        "Reached tokens limit, do you want me to forget earliest message of current chat?")
+                    if delfirst_YN:
+                        self.delete_first_conversation()
                 return
 
             reply_message = self.process_response(response)
@@ -190,13 +197,6 @@ class ChatGPT:
                     console.print(
                         f"[dim]Approaching the tokens limit: {self.tokens_limit - self.current_tokens} tokens left", new_line_start=True)
                 # approaching tokens limit (less than 500 left), show info
-                elif self.current_tokens >= self.tokens_limit:
-                    print()
-                    # writeline
-                    delfirst_YN = confirm(
-                        "Reached tokens limit, do you want me to forget earliest message of current chat?")
-                    if delfirst_YN:
-                        self.delete_first_conversation()
 
         except Exception as e:
             console.print(

--- a/chat.py
+++ b/chat.py
@@ -542,7 +542,8 @@ def handle_command(command: str, chatGPT: ChatGPT):
     /system \[new_prompt]     - Modify the system prompt
     /timeout \[new_timeout]   - Modify the api timeout
     /undo                    - Undo the last question and remove its answer
-    /delete                  - Delete the first conversation in current chat
+    /delete (first)          - Delete the first conversation in current chat
+    /delete all              - Clear all messages and conversations current chat
     /help                    - Show this help message
     /exit                    - Exit the application''')
 


### PR DESCRIPTION
~我又来了~
本次PR更改如下：
- 将 `tokens_limit` 改为 `ChatGPT` 类变量 值更改现由 `set_model` 函数负责
- 在 `ChatGPT` 类内增加 `delete_first_conversation` 函数 用于删除 `messages` 列表内的第一次对话【即 `index=1,2` 一问一答】
- 在使用的tokens接近限制时弹出提醒【默认是在剩余tokens在1~500时提醒 后期可以改自定义】
- ~增加 `/delfirst` 命令 用于删除目前的第一次对话【这个命名貌似不太好 你要不看看改改 或者干脆顺着这个写一个清空目前聊天记录的功能然后以和 `/copy` 命令一样的思路构建命令结构】~ 新commit已经完善为 `/delete` 命令
- 疑似bug修复：chat.py: 481, 482 中曾试图调用置于 `ChatMode` 类下的 `timeout` 变量 但他是被定义在 `ChatGPT` 类下的 我不知道为什么在老版本中进行了这样的修改 但之前确实一旦调用 `/timeout` 命令就会直接报找不到对象退出
  因此将此处改回了 `chatGPT.timeout` 即：
```python
if len(args) > 1:
    new_timeout = args[1]
else:
    new_timeout = prompt(
        "OpenAI API timeout: ", default=str(chatGPT.timeout), style=style)
#                                           ~~~~~~~
if new_timeout != str(chatGPT.timeout):
#                     ~~~~~~~
    chatGPT.set_timeout(new_timeout)
else:
    console.print("[dim]No change.")
```
但我不敢保证这样更改是正确的 你能不能再看一下

另外报告一个问题：
- `/usage` 命令目前疑似失效了 `https://api.openai.com/dashboard/billing/credit_grants` 这个url貌似现在阻止了非浏览器的一切访问 之前问ChatGPT他给出了一样的答复 不知道这样的话usage统计功能是否要重写