### PR TITLE
CLI Titles Extension

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -555,7 +555,9 @@ def handle_command(command: str, chat_gpt: ChatGPT):
             if not new_title:
                 console.print("[red]Failed to generate title.")
                 return
+        # if a title is given, don't generate a new one; otherwise generate
         change_CLI_title(new_title)
+        console.print(f"[dim]CLI Title changed to '{chat_gpt.title}'")
 
     elif command.startswith('/timeout'):
         args = command.split()


### PR DESCRIPTION
## Still in Working, DO NOT Merge

Link Issue #17 

思路为 在输出ChatGPT的回复后检查messages list 如果是此chat的第一次conversation则启动一个支线程向gpt请求标题 在正确回复后更改终端 (CLI) 的标题
主线程不会主动阻塞支线程 仅当在调用 `/save` `/tokens` `/title` 命令时会检查线程状态 若标题请求线程仍在运行则阻塞主线程直至标题请求现场join或异常退出

TO DO:
- [x] 跨平台的CLI标题更改函数
- [x] `/title` 命令 用于手动生成CLI标题并更改
- [ ] 标题请求支线程和支函数
- [ ] 对 `gen_title` 函数中Exception进行审查和扩展
- [ ] 在 `/save` `/tokens` `/title` 等命令中加入线程检查和主线程阻塞函数