### PR TITLE
feat: 反向代理配置支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Uses the [gpt-3.5-turbo](https://platform.openai.com/docs/guides/chat/chat-compl
 
 ## Changelog
 
+### 2023-05-20
+
+- Added host configuration support, which is very useful when using self-built API reverse proxy server ([#49](https://github.com/xiaoxx970/chatgpt-in-terminal/issues/49)), you can now use `gpt-term --set-host HOST` to configure host, the default is https://api.openai.com
+
 ### 2023-05-18
 
 - Added multi-language support: English, Chinese, Japanese, German, follow the system language by default, now you can use `/lang` to switch languages
@@ -155,20 +159,23 @@ Here are some common shortcut keys (also shortcut keys for the shell):
 
 ### Available Arguments
 
-| Arguments     | Description                     | Example                                       |
-| ------------- | ------------------------------- | --------------------------------------------- |
-| -h, --help    | show this help message and exit | `gpt-term --help`                             |
-| --load FILE   | Load chat history from file     | `gpt-term --load chat_history_code_check.json` |
-| --key API_KEY | choose the API key to load      | `gpt-term --key OPENAI_API_KEY1`              |
-| --model MODEL | choose the AI model to use      | `gpt-term --model gpt-3.5-turbo`              |
-| -m, --multi   | Enable multi-line mode          | `gpt-term --multi`                            |
-| -r, --raw     | Enable raw mode                 | `gpt-term --raw`                              |
-| --set-apikey KEY        | Set the OpenAI API key                                   | `gpt-term --set-apikey sk-xxx`   |
-| --set-timeout SEC       | Set the maximum wait time for API requests               | `gpt-term --set-timeout 10`      |
-| --set-gentitle BOOL     | Set whether to auto-generate a title for the chat        | `gpt-term --set-gentitle True`   |
-| --set-saveperfix PERFIX | Set the save prefix for chat history files               | `gpt-term --set-saveperfix chat_history_` |
-| --set-loglevel LEVEL    | Set the log level: DEBUG, INFO, WARNING, ERROR, CRITICAL | `gpt-term --set-loglevel DEBUG`  |
-| --set-lang LANG    | Set the language: en, zh_CN, jp, de | `gpt-term --set-lang en` |
+| Arguments | Description | Examples |
+| ------------- | --------------------------------- | - ----------------------------------------------- |
+| -h, --help | show this help message and exit | `gpt-term --help` |
+| --load FILE | Load chat history from file | `gpt-term --load chat_history_code_check.json` |
+| --key API_KEY | Select the API key to use in the config.ini file | `gpt-term --key OPENAI_API_KEY1` |
+| --model MODEL | Select AI model to use | `gpt-term --model gpt-3.5-turbo` |
+| --host HOST | Set the API Host address used in this run (this is usually used to configure proxy) | `gpt-term --host https://closeai.deno.dev` |
+| -m, --multi | Enable multiline mode | `gpt-term --multi` |
+| -r, --raw | Enable raw mode | `gpt-term --raw` |
+| -l, --lang LANG | Set the current running language: en, zh_CN, jp, de | `gpt-term --lang en` |
+| --set-host HOST | Set API Host address (this is usually used to configure proxy) | `gpt-term --set-host https://closeai.deno.dev` |
+| --set-apikey KEY | Set OpenAI API key | `gpt-term --set-apikey sk-xxx` |
+| --set-timeout SEC | Set the maximum wait time for API requests | `gpt-term --set-timeout 10` |
+| --set-gentitle BOOL | Set whether to auto-generate title for chat | `gpt-term --set-gentitle True` |
+| --set-saveperfix PERFIX | Set the save prefix for chat history files | `gpt-term --set-saveperfix chat_history_` |
+| --set-loglevel LEVEL | Set log level: DEBUG, INFO, WARNING, ERROR, CRITICAL | `gpt-term --set-loglevel DEBUG` |
+| --set-lang LANG | Set language: en, zh_CN, jp, de | `gpt-term --set-lang en` |
 
 > Multi-line mode and raw mode can be used simultaneously
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,6 +29,10 @@
 
 ## 更新记录
 
+### 2023-05-20
+
+- 新增 host 配置项支持，在使用自建 API 反向代理服务器的时候很有用([#49](https://github.com/xiaoxx970/chatgpt-in-terminal/issues/49))，你现在可以使用 `gpt-term --set-host HOST` 来配置 host，默认为 https://api.openai.com。
+
 ### 2023-05-18
 
 - 新增多语言支持：英语、中文、日语、德语，默认跟随系统语言，现在可以使用 `/lang` 来切换语言
@@ -164,10 +168,13 @@ python3 -m gpt_term
 | --load FILE   | 从文件中加载聊天记录              | `gpt-term --load chat_history_code_check.json` |
 | --key API_KEY | 选择 config.ini 文件中要使用的 API 密钥 | `gpt-term --key OPENAI_API_KEY1`              |
 | --model MODEL | 选择要使用的 AI 模型              | `gpt-term --model gpt-3.5-turbo`              |
+| --host HOST | 设置在本次运行中使用的 API Host 地址（这通常被用来配置代理） | `gpt-term --host https://closeai.deno.dev`              |
 | -m, --multi   | 启用多行模式                      | `gpt-term --multi`                            |
 | -r, --raw     | 启用原始模式                      | `gpt-term --raw`                              |
+| -l, --lang LANG | 设置本次运行语言：en, zh_CN, jp, de | `gpt-term --lang en` |
+| --set-host HOST        | 设置API Host地址（这通常被用来配置代理）              | `gpt-term --set-host https://closeai.deno.dev` |
 | --set-apikey KEY        | 设置 OpenAI 的 API 密钥                          | `gpt-term --set-apikey sk-xxx` |
-| --set-timeout SEC       | 设置 API 请求的最大等待时间                         | `gpt-term --set-timeout 10` |
+| --set-timeout SEC       | 设置 API 请求的最大等待时间                        | `gpt-term --set-timeout 10` |
 | --set-gentitle BOOL     | 设置是否为聊天自动生成标题                          | `gpt-term --set-gentitle True` |
 | --set-saveperfix PERFIX | 设置聊天历史文件的保存前缀                          | `gpt-term --set-saveperfix chat_history_` |
 | --set-loglevel LEVEL    | 设置日志级别：DEBUG, INFO, WARNING, ERROR, CRITICAL | `gpt-term --set-loglevel DEBUG` |

--- a/gpt_term/config.ini
+++ b/gpt_term/config.ini
@@ -15,3 +15,6 @@ LOG_LEVEL=INFO
 
 # Set the language of the program, the default is empty, it will follow the system language
 LANGUAGE=
+
+# Set the host of the api, the default is https://api.openai.com
+openai_host=

--- a/gpt_term/locale/gpt_term.de.yml
+++ b/gpt_term/locale/gpt_term.de.yml
@@ -41,6 +41,8 @@ de:
   usage_title: "Kredit Statistik"
   usage_plan: "[bright_blue]Plan: %{credit_plan}"
   #
+  host_set: "[dim]API Host wurde auf '%{new_host}' gesetzt."
+  #
   model_set: "[dim]Leere Eingabe, erhält das Modell '%{old_model}' unverändert."
   model_changed: "[dim]Das Modell wurde von '%{old_model}' auf '%{new_model}' geändert."
   #
@@ -101,7 +103,6 @@ de:
   lang_switch: "[dim]Wechselt zu [bright_magenta]Deutsch[/]."
   lang_config_unsupport: "[red]Nicht unterstützte Sprache in der Konfiguration `%{config_lang}`. Die Sprache des Benutzers wird verwendet."
   lang_unsupport: "[red]Nicht unterstützte Sprache `%{new_lang}`."
-
   #
   upgrade_title: "Neue Version verfügbar: [red]v%{local_version}[/] -> [green]v%{remote_version}[/]"
   upgrade_use_command: "Verwenden `pip install --upgrade gpt-term` zum Upgrade."
@@ -113,9 +114,11 @@ de:
   help_load: "Chatverlauf aus Datei laden"
   help_key: "Wählen Sie den Namen des API-Schlüssels aus, der aus der Konfigurationsdatei geladen werden soll."
   help_model: "Wählen das zu verwendende AI-Modell"
+  help_host: "Stellen den API Host ein, der in diesem Lauf verwendet werden (wird normalerweise zur Konfiguration des Proxys verwendet)"
   help_m: "Aktivieren den Multi-Linie-Mode"
   help_r: "Aktivieren den Rhomode"
   help_lang: "Sprache wählen"
+  help_set_host: "API Host einstellen (wird normalerweise zur Konfiguration des Proxys verwendet)"
   help_set_key: "API-Schlüssel für OpenAI einstellen"
   help_set_timeout: "Maximale Wartezeit für API-Anfragen einstellen"
   help_set_gentitle: "Festlegen, ob automatisch ein Titel für den Chat generiert werden soll"

--- a/gpt_term/locale/gpt_term.en.yml
+++ b/gpt_term/locale/gpt_term.en.yml
@@ -41,6 +41,8 @@ en:
   usage_title: "Credit Summary"
   usage_plan: "[bright_blue]Plan: %{credit_plan}"
   #
+  host_set: "[dim]API Host set to '%{new_host}'."
+  #
   model_set: "[dim]Empty input, the model remains '%{old_model}'."
   model_changed: "[dim]Model has been set from '%{old_model}' to '%{new_model}'."
   #
@@ -112,9 +114,11 @@ en:
   help_load: "Load chat history from file"
   help_key: "Choose the name of API key in config file to load"
   help_model: "Choose the AI model to use"
+  help_host: "Set the API Host to use in this run (usually used to configure proxy)"
   help_m: "Enable multi-line mode"
   help_r: "Enable raw mode"
   help_lang: "Choose language"
+  help_set_host: "Set the API Host to use (usually used to configure proxy)"
   help_set_key: "Set API key for OpenAI"
   help_set_timeout: "Set maximum waiting time for API requests"
   help_set_gentitle: "Set whether to automatically generate a title for chat"

--- a/gpt_term/locale/gpt_term.jp.yml
+++ b/gpt_term/locale/gpt_term.jp.yml
@@ -41,6 +41,8 @@ jp:
   usage_title: "クレジットの概要"
   usage_plan: "[bright_blue]プラン： %{credit_plan}"
   #
+  host_set: "[dim]APIホストが '%{new_host}' に設定されました。"
+  #
   model_set: "[dim]空の入力です。モデルは'%{old_model}'のままです。"
   model_changed: "[dim]モデルが'%{old_model}'から'%{new_model}'に変更されました。"
   #
@@ -96,13 +98,11 @@ jp:
   #
   load_file_not: "[bright_red]ファイルが見つかりません：%{file_path}"
   load_json_error: "[bright_red]ファイル内の無効なJSON形式です：%{file_path}"
-  
   #
   new_lang_prompt: "言語："
   lang_switch: "[dim]すでに[bright_magenta]日本語[/]に切り替わっています。"
   lang_config_unsupport: "[red]設定でサポートされていない言語 `%{config_lang}` です。ユーザーのローカル言語が使用されます。"
   lang_unsupport: "[red]サポートされていない言語 `%{new_lang}` です。"
-
   #
   upgrade_title: "新しいバージョンが利用可能です：[red]v%{local_version}[/] -> [green]v%{remote_version}[/]"
   upgrade_use_command: "`pip install --upgrade gpt-term`\nを使用してアップグレードしてください。"
@@ -114,9 +114,11 @@ jp:
   help_load: "チャット履歴をファイルから読み込む"
   help_key: "設定ファイルから読み込む API キーの名前を選択してください。"
   help_model: "使用するAIモデルを選択する"
+  help_host: "この実行で使用するAPIホストを設定する（通常、プロキシを設定するために使用します。）"
   help_m: "マルチラインモードを有効にする"
   help_r: "ロー モードを有効にする"
   help_lang: "言語を選択する"
+  help_set_host: "使用するAPIホストを設定する（通常、プロキシを設定するために使用します。）"
   help_set_key: "OpenAIのAPIキーを設定する"
   help_set_timeout: "APIリクエストの最大待ち時間を設定する"
   help_set_gentitle: "チャットのタイトルを自動生成するかどうかを設定する"

--- a/gpt_term/locale/gpt_term.zh_CN.yml
+++ b/gpt_term/locale/gpt_term.zh_CN.yml
@@ -41,6 +41,8 @@ zh_CN:
   usage_title: "额度摘要"
   usage_plan: "[bright_blue]计划: %{credit_plan}"
   #
+  host_set: "[dim]API主机地址已被设为 '%{new_host}'"
+  #
   model_set: "[dim]输入为空，模型保持为 '%{old_model}'."
   model_changed: "[dim]模型已从 '%{old_model}' 修改为 '%{new_model}'."
   #
@@ -112,9 +114,11 @@ zh_CN:
   help_load: "从文件中加载聊天历史记录"
   help_key: "选择要从配置文件加载的API密钥名称"
   help_model: "选择要使用的AI模型"
+  help_host: "设置在本次运行中使用的API Host地址（这通常被用来配置代理）"
   help_m: "启用多行模式"
   help_r: "启用原始模式"
   help_lang: "选择语言"
+  help_set_host: "设置API Host地址（这通常被用来配置代理）"
   help_set_key: "设置OpenAI的API密钥"
   help_set_timeout: "设置API请求的最大等待时间"
   help_set_gentitle: "设置是否自动生成聊天标题"

--- a/gpt_term/main.py
+++ b/gpt_term/main.py
@@ -1130,7 +1130,7 @@ def main():
 
     if args.host:
         chat_gpt.set_host(args.host)
-        console.print(_("gpt_term.model_set", model=args.host))
+        console.print(_("gpt_term.host_set", new_host=args.host))
 
     if args.model:
         chat_gpt.set_model(args.model)

--- a/gpt_term/main.py
+++ b/gpt_term/main.py
@@ -479,6 +479,7 @@ class ChatGPT:
     
     def set_host(self, host: str):
         self.host = host
+        self.endpoint = self.host + "/v1/chat/completions"
 
     def modify_system_prompt(self, new_content: str):
         if self.messages[0]['role'] == 'system':

--- a/gpt_term/main.py
+++ b/gpt_term/main.py
@@ -1008,7 +1008,10 @@ def set_config_by_args(args: argparse.Namespace, config_ini: ConfigParser):
     if args.set_loglevel:   config_need_to_set.update({"LOG_LEVEL"           : args.set_loglevel})
     if args.set_gentitle:   config_need_to_set.update({"AUTO_GENERATE_TITLE" : args.set_gentitle})
     # 新的语言设置:
-    if args.set_lang:       config_need_to_set.update({"LANGUAGE"            : args.set_lang})
+    if args.set_lang:       
+        config_need_to_set.update({"LANGUAGE": args.set_lang})
+        _=set_lang(args.set_lang)
+    # here: when set lang is called, set language before printing 'set-successful' messages
 
     if len(config_need_to_set) == 0:
         return


### PR DESCRIPTION
## Done, Requires Code Review

Link Issue: #49 

增加了 `--host` 和 `--set-host` 用于单次/多次更改API Host地址
同时做好了所有语种的翻译 日语基于DeepL【个人习惯】

另外做了一个小改动 在调用 `--set-lang` 之后会加载一次lang再输出信息 这样子的话输出信息就会是设置好的新语言了而不是旧的