### PR TITLE
Fix error timeout message key

### DIFF
--- a/gpt_term/main.py
+++ b/gpt_term/main.py
@@ -408,7 +408,7 @@ class ChatGPT:
             raise
         except requests.exceptions.ReadTimeout as e:
             console.print(
-                _("gpt_term.Error_timeot",timeout=self.timeout), highlight=False)
+                _("gpt_term.Error_timeout", timeout=self.timeout), highlight=False)
             return None
         except requests.exceptions.RequestException as e:
             console.print(_("gpt_term.Error_message",error_msg=str(e)))


### PR DESCRIPTION
## Summary
- fix typo in timeout error message key

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pip install flake8`
- `flake8` *(fails: Broken pipe)*

------
https://chatgpt.com/codex/tasks/task_e_683ff4602550832cadc43af50abe5b1f