### PR TITLE
Fix title prompt typo

### DIFF
--- a/gpt_term/main.py
+++ b/gpt_term/main.py
@@ -322,7 +322,7 @@ class ChatGPT:
         # this is a silent sub function, only for sub thread which auto-generates title when first conversation is made and debug functions
         # it SHOULD NOT be triggered or used by any other functions or commands
         # because of the usage of this subfunction, no check for messages list length and title appearance is needed
-        prompt = f'Generate title shorter than 10 words for the following content in content\'s language. The tilte contains ONLY words. DO NOT include line-break. \n\nContent: """\n{content}\n"""'
+        prompt = f'Generate title shorter than 10 words for the following content in content\'s language. The title contains ONLY words. DO NOT include line-break. \n\nContent: """\n{content}\n"""'
         messages = [{"role": "user", "content": prompt}]
         data = {
             "model": "gpt-3.5-turbo",


### PR DESCRIPTION
## Summary
- fix misspelled word in `gen_title_silent` prompt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff51bc474832c83829ccf4b17ba76